### PR TITLE
Group meetup locations into columns

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -17,6 +17,7 @@ activate :directory_indexes
 activate :toc
 activate :highlighter
 activate :alias
+activate :column_balancer
 activate :ember do |config|
   config.templates_root = 'app/builds/templates'
 end

--- a/lib/column_balancer.rb
+++ b/lib/column_balancer.rb
@@ -1,0 +1,40 @@
+module ColumnBalancer
+  class << self
+    def registered(app)
+      app.helpers Helpers
+    end
+    alias :included :registered
+  end
+
+  module Helpers
+    def balance(groups, columns)
+      item_counts = groups.map { |k, v| v.count }
+      output = Array.new(columns) { Hash.new }
+      c = 0
+
+      while c < columns - 1 && groups.count > 1 do
+        ideal = groups.values.flatten.count / (columns - c)
+        index_high, index_low, i = item_counts[1] + item_counts[0], item_counts[0], 1
+        while index_high < ideal do
+          index_high += item_counts[i + 1]
+          index_low += item_counts[i]
+          i += 1
+        end
+
+        index = (index_high - ideal).abs < (index_low - ideal).abs ? i + 1 : i
+        column = groups.first(index).map { |arr| { arr[0] => arr[1] } }.reduce(:merge)
+
+        output[c] = column
+
+        groups = groups.drop(index).map { |arr| { arr[0] => arr[1] } }.reduce(:merge)
+        item_counts = item_counts.drop(index)
+        c += 1
+      end
+
+      output[c] = groups
+      return output
+    end
+  end
+end
+
+::Middleman::Extensions.register(:column_balancer, ColumnBalancer)

--- a/source/meetups.html.erb
+++ b/source/meetups.html.erb
@@ -13,14 +13,16 @@ title: "Meetups"
 <div class="meetups section list">
   <table class="columns">
     <tr>
-      <% data.meetups.locations.each do |name, groups| %>
+      <% balance(data.meetups.locations, 3).each do |column| %>
         <td>
-          <h3><%= name %></h3>
-          <ul>
-            <% groups.sort_by(&:location).each do |group| %>
-              <li><%= link_to group.location, group.url %></li>
-            <% end %>
-          </ul>
+          <% column.each do |name, groups| %>
+            <h3><%= name %></h3>
+            <ul>
+              <% groups.sort_by(&:location).each do |group| %>
+                <li><%= link_to group.location, group.url %></li>
+              <% end %>
+            </ul>
+          <% end %>
         </td>
       <% end %>
     </tr>
@@ -33,4 +35,3 @@ title: "Meetups"
 </div>
 
 <script src="/javascripts/meetups.js"></script>
-


### PR DESCRIPTION
Completes “Show all groups in the meetup list” in emberjs/website#1904.

The extension takes the list of meetup locations and divides them as evenly as possible over a variable number of columns, without splitting regions. It does feel a little heavy-handed for layout, but I think even Flexbox doesn’t handle this case (yet? citation needed). At any rate, this works and is compatible across the board.
