### PR TITLE
Rake geocode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "rails-assets-js-md5"
 gem "rails-assets-moment"
 gem "underscore-rails"
 gem "gmaps4rails"
+gem "geocoder"
 
 group :development, :test do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
     execjs (2.2.2)
     ffi (1.9.6)
     ffi (1.9.6-x86-mingw32)
+    geocoder (1.2.6)
     gmaps4rails (2.1.2)
     haml (4.0.6)
       tilt
@@ -214,6 +215,7 @@ DEPENDENCIES
   capybara
   coderay!
   ember-middleman
+  geocoder
   gmaps4rails
   highline
   listen

--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,7 @@
 
 require "bundler/setup"
 require 'yaml'
+require 'geocoder'
 
 def git_initialize(repository)
   unless File.exist?(".git")
@@ -89,6 +90,32 @@ def generate_ember_data_docs
   puts "Built #{repo_path} with SHA #{sha}"
 end
 
+def geocode_meetups
+  data_path = 'meetups.yml'
+  puts "Geocoding records from #{data_path}... "
+
+  data = YAML.load_file(File.expand_path("./data/#{data_path}"))
+  data["locations"].each do |loc|
+    loc["groups"].each do |group|
+      next if group.has_key?("lat") and group.has_key?("lat")
+      coord = Geocoder.coordinates(group["address"]) || Geocoder.coordinates(group["location"])
+      if coord.nil?
+        puts "Unable to find coordinates for #{group["location"]}"
+        next
+      end
+      group["lat"] = coord[0]
+      group["lng"] = coord[1]
+      puts "Found coordinates for #{group["location"]}"
+      #throttle requests to API to avoid errors
+      sleep 0.1
+    end
+  end
+
+  File.open(File.expand_path("../data/#{data_path}", __FILE__), "w") do |f|
+    YAML.dump(data, f)
+  end
+end
+
 def build
   system "middleman build"
 end
@@ -154,4 +181,9 @@ task :deploy do |t, args|
     system "git commit -m '#{message.gsub("'", "\\'")}'"
     system "git push origin master" unless ENV['NODEPLOY']
   end
+end
+
+desc "Find coordinates for meetup locations"
+task :geocode do
+  geocode_meetups
 end

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@
 
 require "bundler/setup"
 require 'yaml'
-require 'geocoder'
+require './lib/meetups_data'
 
 def git_initialize(repository)
   unless File.exist?(".git")
@@ -97,17 +97,7 @@ def geocode_meetups
   data = YAML.load_file(File.expand_path("./data/#{data_path}"))
   data["locations"].each do |loc|
     loc["groups"].each do |group|
-      next if group.has_key?("lat") and group.has_key?("lat")
-      coord = Geocoder.coordinates(group["address"]) || Geocoder.coordinates(group["location"])
-      if coord.nil?
-        puts "Unable to find coordinates for #{group["location"]}"
-        next
-      end
-      group["lat"] = coord[0]
-      group["lng"] = coord[1]
-      puts "Found coordinates for #{group["location"]}"
-      #throttle requests to API to avoid errors
-      sleep 0.1
+      MeetupsData::GroupGeocoder.from_hash(group).find_location
     end
   end
 

--- a/lib/meetups_data.rb
+++ b/lib/meetups_data.rb
@@ -1,0 +1,50 @@
+require 'geocoder'
+
+module MeetupsData
+  class GroupGeocoder
+    attr_reader :data
+
+    def initialize(data)
+      @data = data
+    end
+
+    def find_location
+      return if has_coordinates?
+      coord = geocode(address) || geocode(location)
+      if coord.nil?
+        yield "Unable to find coordinates for #{data["location"]}" if block_given?
+        return
+      end
+      data["lat"] = coord[0]
+      data["lng"] = coord[1]
+      yield "Found coordinates for #{data["location"]}" if block_given?
+      #throttle requests to API to avoid errors
+      sleep 0.1
+    end
+
+    def geocode(place_name)
+      return nil if place_name.nil?
+      Geocoder.coordinates(place_name)
+    end
+
+    def has_coordinates?
+      data.has_key?("lng") and data.has_key?("lat")
+    end
+
+    def address
+      data["address"]
+    end
+
+    def location
+      data["location"]
+    end
+
+    def location_text
+      Geocoder.coordinates(data["address"]) || Geocoder.coordinates(data["location"])
+    end
+
+    def self.from_hash(data)
+      self.new(data)
+    end
+  end
+end

--- a/source/javascripts/meetups.js
+++ b/source/javascripts/meetups.js
@@ -45,7 +45,9 @@
 
   handler.buildMap(mapOptions, function() {
     if(navigator.geolocation) {
-      var geoLocation = navigator.geolocation.getCurrentPosition(drawMap);
+      var geoLocation = navigator.geolocation.getCurrentPosition(drawMap, function(){
+        drawMap();
+      });
     } else {
       drawMap();
     }
@@ -91,7 +93,10 @@
       });
       handler.map.centerOn(marker);
       handler.bounds.extendWith(marker);
+      handler.getMap().setZoom(8)
     }
-    handler.getMap().setZoom(8)
+    else {
+      handler.fitMapToBounds();
+    }
   }
 })();

--- a/source/javascripts/meetups.js
+++ b/source/javascripts/meetups.js
@@ -45,9 +45,7 @@
 
   handler.buildMap(mapOptions, function() {
     if(navigator.geolocation) {
-      var geoLocation = navigator.geolocation.getCurrentPosition(drawMap, function(){
-        drawMap();
-      });
+      var geoLocation = navigator.geolocation.getCurrentPosition(drawMap);
     } else {
       drawMap();
     }
@@ -93,10 +91,7 @@
       });
       handler.map.centerOn(marker);
       handler.bounds.extendWith(marker);
-      handler.getMap().setZoom(8)
     }
-    else {
-      handler.fitMapToBounds();
-    }
+    handler.getMap().setZoom(8)
   }
 })();


### PR DESCRIPTION
This is a new pull request to replace [my previous one](https://github.com/sandraor/website/pull/3)

The geocode rake task will now simply calculate lng/lat fields for the group records in meetups.yml where no such values already exist. It will use an 'address' field if it find one (this allows specifying a more accurate street address to geocode), otherwise it will use the location field to geocode to a general coordinate in the city.

I have also included a commit which allows the map to go ahead and draw even in the case when the user does not permit the geolocation API to lookup the current location. In this case the map is displayed to the extent of all the markers. Previously in this case the map would display without any of the markers.
