### PR TITLE
Removed link to nowhere

### DIFF
--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -73,5 +73,5 @@ title: "Community"
     Ember is a new and growing community, and we're working to create learning resources as fast as we can. We've compiled a list of useful places to look for content other than our <a href="/guides">documentation</a>.
   </p>
 
-  <a class="orange button" href="/community/resources">See our list of resources</a>
+  <a class="orange button">Coming Soon!</a>
 </div>


### PR DESCRIPTION
Since we don't have the resources page yet, I added a "coming soon" and removed the link.

https://github.com/emberjs/website/pull/1904
